### PR TITLE
patch for mongomirror

### DIFF
--- a/mongodump/metadata_dump.go
+++ b/mongodump/metadata_dump.go
@@ -3,6 +3,7 @@ package mongodump
 import (
 	"bufio"
 	"fmt"
+
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/intents"
@@ -53,7 +54,7 @@ func (dump *MongoDump) dumpMetadata(intent *intents.Intent) error {
 	// that list as the "indexes" field of the metadata document.
 	log.Logvf(log.DebugHigh, "\treading indexes for `%v`", nsID)
 
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}

--- a/mongodump/mongodump_test.go
+++ b/mongodump/mongodump_test.go
@@ -3,6 +3,13 @@ package mongodump
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/json"
@@ -13,12 +20,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"testing"
 )
 
 var (
@@ -69,7 +70,7 @@ func simpleMongoDumpInstance() *MongoDump {
 func getBareSession() (*mgo.Session, error) {
 	ssl := testutil.GetSSLOptions()
 	auth := testutil.GetAuthOptions()
-	sessionProvider, err := db.NewSessionProvider(options.ToolOptions{
+	SessionProvider, err := db.NewSessionProvider(options.ToolOptions{
 		Connection: &options.Connection{
 			Host: testServer,
 			Port: testPort,
@@ -80,7 +81,7 @@ func getBareSession() (*mgo.Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	session, err := sessionProvider.GetSession()
+	session, err := SessionProvider.GetSession()
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +435,7 @@ func TestMongoDumpBSON(t *testing.T) {
 				Convey("it dumps to standard output", func() {
 					md.OutputOptions.Out = "-"
 					stdoutBuf := &bytes.Buffer{}
-					md.stdout = stdoutBuf
+					md.OutputWriter = stdoutBuf
 					err = md.Dump()
 					So(err, ShouldBeNil)
 					var count int

--- a/mongodump/oplog_dump.go
+++ b/mongodump/oplog_dump.go
@@ -2,6 +2,7 @@ package mongodump
 
 import (
 	"fmt"
+
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/log"
 	"github.com/mongodb/mongo-tools/common/util"
@@ -12,7 +13,7 @@ import (
 // the name of the oplog collection in the connected db
 func (dump *MongoDump) determineOplogCollectionName() error {
 	masterDoc := bson.M{}
-	err := dump.sessionProvider.Run("isMaster", &masterDoc, "admin")
+	err := dump.SessionProvider.Run("isMaster", &masterDoc, "admin")
 	if err != nil {
 		return fmt.Errorf("error running command: %v", err)
 	}
@@ -38,7 +39,7 @@ func (dump *MongoDump) determineOplogCollectionName() error {
 func (dump *MongoDump) getOplogStartTime() (bson.MongoTimestamp, error) {
 	mostRecentOplogEntry := db.Oplog{}
 
-	err := dump.sessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"-$natural"}, &mostRecentOplogEntry, 0)
+	err := dump.SessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"-$natural"}, &mostRecentOplogEntry, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -51,7 +52,7 @@ func (dump *MongoDump) getOplogStartTime() (bson.MongoTimestamp, error) {
 // captured at the start of the dump.
 func (dump *MongoDump) checkOplogTimestampExists(ts bson.MongoTimestamp) (bool, error) {
 	oldestOplogEntry := db.Oplog{}
-	err := dump.sessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"+$natural"}, &oldestOplogEntry, 0)
+	err := dump.SessionProvider.FindOne("local", dump.oplogCollection, 0, nil, []string{"+$natural"}, &oldestOplogEntry, 0)
 	if err != nil {
 		return false, fmt.Errorf("unable to read entry from oplog: %v", err)
 	}
@@ -68,7 +69,7 @@ func (dump *MongoDump) checkOplogTimestampExists(ts bson.MongoTimestamp) (bool, 
 // DumpOplogAfterTimestamp takes a timestamp and writer and dumps all oplog entries after
 // the given timestamp to the writer. Returns any errors that occur.
 func (dump *MongoDump) DumpOplogAfterTimestamp(ts bson.MongoTimestamp) error {
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}

--- a/mongodump/prepare.go
+++ b/mongodump/prepare.go
@@ -5,16 +5,17 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/mongodb/mongo-tools/common/archive"
 	"github.com/mongodb/mongo-tools/common/bsonutil"
 	"github.com/mongodb/mongo-tools/common/db"
 	"github.com/mongodb/mongo-tools/common/intents"
 	"github.com/mongodb/mongo-tools/common/log"
 	"gopkg.in/mgo.v2/bson"
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type NilPos struct{}
@@ -236,7 +237,7 @@ func (dump *MongoDump) NewIntent(dbName, colName string) (*intents.Intent, error
 		C:  colName,
 	}
 	if dump.OutputOptions.Out == "-" {
-		intent.BSONFile = &stdoutFile{Writer: dump.stdout}
+		intent.BSONFile = &stdoutFile{Writer: dump.OutputWriter}
 	} else {
 		if dump.OutputOptions.Archive != "" {
 			intent.BSONFile = &archive.MuxIn{Intent: intent, Mux: dump.archive.Mux}
@@ -263,7 +264,7 @@ func (dump *MongoDump) NewIntent(dbName, colName string) (*intents.Intent, error
 	}
 
 	// get a document count for scheduling purposes
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +346,7 @@ func (dump *MongoDump) CreateCollectionIntent(dbName, colName string) error {
 		return err
 	}
 
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}
@@ -394,7 +395,7 @@ func (dump *MongoDump) createIntentFromOptions(dbName string, ci *collectionInfo
 func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 	// we must ensure folders for empty databases are still created, for legacy purposes
 
-	session, err := dump.sessionProvider.GetSession()
+	session, err := dump.SessionProvider.GetSession()
 	if err != nil {
 		return err
 	}
@@ -432,7 +433,7 @@ func (dump *MongoDump) CreateIntentsForDatabase(dbName string) error {
 // CreateAllIntents iterates through all dbs and collections and builds
 // dump intents for each collection.
 func (dump *MongoDump) CreateAllIntents() error {
-	dbs, err := dump.sessionProvider.DatabaseNames()
+	dbs, err := dump.SessionProvider.DatabaseNames()
 	if err != nil {
 		return fmt.Errorf("error getting database names: %v", err)
 	}

--- a/mongorestore/filepath.go
+++ b/mongorestore/filepath.go
@@ -463,7 +463,7 @@ func (restore *MongoRestore) CreateStdinIntentForCollection(db string, collectio
 		C:        collection,
 		Location: "-",
 	}
-	intent.BSONFile = &stdinFile{Reader: restore.stdin}
+	intent.BSONFile = &stdinFile{Reader: restore.InputReader}
 	restore.manager.Put(intent)
 	return nil
 }

--- a/mongorestore/metadata.go
+++ b/mongorestore/metadata.go
@@ -495,6 +495,9 @@ func (restore *MongoRestore) ValidateAuthVersions() error {
 // ShouldRestoreUsersAndRoles returns true if mongorestore should go through
 // through the process of restoring collections pertaining to authentication.
 func (restore *MongoRestore) ShouldRestoreUsersAndRoles() bool {
+	if restore.SkipUsersAndRoles {
+		return false
+	}
 	// If the user has done anything that would indicate the restoration
 	// of users and roles (i.e. used --restoreDbUsersAndRoles, -d admin, or
 	// is doing a full restore), then we check if users or roles BSON files

--- a/mongorestore/mongorestore_test.go
+++ b/mongorestore/mongorestore_test.go
@@ -75,7 +75,7 @@ func TestMongorestore(t *testing.T) {
 			restore.NSOptions.Collection = "c1"
 			restore.NSOptions.DB = "db1"
 			So(err, ShouldBeNil)
-			restore.stdin = bsonFile
+			restore.InputReader = bsonFile
 			restore.TargetDirectory = "-"
 			err = restore.Restore()
 			So(err, ShouldBeNil)

--- a/mongorestore/restore.go
+++ b/mongorestore/restore.go
@@ -23,9 +23,9 @@ const (
 // RestoreIntents iterates through all of the intents stored in the IntentManager, and restores them.
 func (restore *MongoRestore) RestoreIntents() error {
 	// start up the progress bar manager
-	restore.progressManager = progress.NewProgressBarManager(log.Writer(0), progressBarWaitTime)
-	restore.progressManager.Start()
-	defer restore.progressManager.Stop()
+	restore.ProgressManager = progress.NewProgressBarManager(log.Writer(0), progressBarWaitTime)
+	restore.ProgressManager.Start()
+	defer restore.ProgressManager.Stop()
 
 	log.Logvf(log.DebugLow, "restoring up to %v collections in parallel", restore.OutputOptions.NumParallelCollections)
 
@@ -225,8 +225,8 @@ func (restore *MongoRestore) RestoreCollectionToDB(dbName, colName string,
 		BarLength: progressBarLength,
 		IsBytes:   true,
 	}
-	restore.progressManager.Attach(bar)
-	defer restore.progressManager.Detach(bar)
+	restore.ProgressManager.Attach(bar)
+	defer restore.ProgressManager.Detach(bar)
 
 	maxInsertWorkers := restore.OutputOptions.NumInsertionWorkers
 	if restore.OutputOptions.MaintainInsertionOrder {


### PR DESCRIPTION
@craiggwilson @shaneharvey @behackett @deafgoat @gabrielrussell

I figure this is an easy place to start reviews for mongomirror. If you want to look at the whole project, you can do so here: https://github.com/10gen/mongomirror/tree/develop

These changes are necessary to allow mongomirror to reuse the code in mongodump and mongorestore. The following specific changes are made:

- Add a `SkipUsersAndRoles` bool member to each of the MongoDump and MongoRestore structs. When this flag is `true`, we skip dumping or restoring any users. MongoMirror doesn't migrate users (likely to cause issues with permissions on Atlas), and it is outside the scope of the tool at the moment.
- Instead of reading always from stdin/writing to stdout, allow mongodump/restore to take in a reader/writer, so the two can be piped together.
- Export the `SessionProvider` member from the MongoDump/Restore structs, so we can reuse these throughout mongomirror.
- Export the `ProgressManager` member from the MongoDump/Restore structs, so we can turn off the meter for mongodump (confusing output). Eventually, we can probably output something more informative than just the progress bars from mongorestore.

Eventually, we can hopefully merge some or all of these changes upstream, since none of these changes is user-facing. For now, mongomirror is tied to version 3.3.11 of mongo-tools (likely to be upgraded before release) and patches mongo-tools directly. See https://github.com/10gen/mongomirror/blob/develop/build.sh for details on how this gets done.
